### PR TITLE
Enhance error messages logging the statement executed with error (#28)

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 
 	"github.com/eaneto/grotto/internal/registry"
 	"github.com/eaneto/grotto/pkg/database"
@@ -75,12 +77,16 @@ func (executor ScriptExecutorSQL) executeScriptAndMarkAsExecuted(script database
 // executeScript Executes a given SQL script.
 func executeScript(tx *sql.Tx, script database.SQLScript) error {
 	logrus.Info("Executing script: ", script.Name)
-	_, err := tx.Exec(script.Content)
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"script_name": script.Name,
-		}).Error("Error executing script.\n", err)
-		return err
+	for _, statement := range strings.Split(script.Content, ";") {
+		_, err := tx.Exec(statement)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"script_name": script.Name,
+			}).Error("Error executing script.", err)
+			fmt.Println("Statement executed:")
+			fmt.Println(statement)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Before this change the only information logged was the script filename. This created a problem on a script with multiple statements, you had to dig into the script to understand which statement was the incorrect one, by splitting the script into statements and executing them one by one makes it easier to debug.

Closes #28